### PR TITLE
Update ffi to 1.0.0

### DIFF
--- a/example/lib/highlight.dart
+++ b/example/lib/highlight.dart
@@ -53,7 +53,8 @@ class CodeInputController extends TextEditingController {
   Future<void> spanCall;
 
   @override
-  TextSpan buildTextSpan({TextStyle style, bool withComposing}) {
+  TextSpan buildTextSpan(
+      {@required BuildContext context, TextStyle style, bool withComposing}) {
     String oldText = oldSpan.toPlainText();
     String newText = value.text;
     if (oldText == newText) return oldSpan;

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -75,7 +75,7 @@ class _TestPageState extends State<TestPage> {
               scrollDirection: Axis.horizontal,
               child: Row(
                 children: [
-                  FlatButton(
+                  TextButton(
                       child: Text("evaluate"),
                       onPressed: () async {
                         await _ensureEngine();
@@ -88,7 +88,7 @@ class _TestPageState extends State<TestPage> {
                         }
                         setState(() {});
                       }),
-                  FlatButton(
+                  TextButton(
                       child: Text("reset engine"),
                       onPressed: () async {
                         if (engine == null) return;

--- a/lib/src/engine.dart
+++ b/lib/src/engine.dart
@@ -62,11 +62,11 @@ class FlutterQjs {
                 ));
           case JSChannelType.MODULE:
             if (moduleHandler == null) throw JSError('No ModuleHandler');
-            final ret = Utf8.toUtf8(moduleHandler(
-              Utf8.fromUtf8(ptr.cast<Utf8>()),
-            ));
+            final ret = moduleHandler(
+              ptr.cast<Utf8>().toDartString(),
+            ).toNativeUtf8();
             Future.microtask(() {
-              free(ret);
+              malloc.free(ret);
             });
             return ret;
           case JSChannelType.PROMISE_TRACK:

--- a/lib/src/ffi.dart
+++ b/lib/src/ffi.dart
@@ -309,17 +309,17 @@ Pointer jsEval(
   String filename,
   int evalFlags,
 ) {
-  final utf8input = Utf8.toUtf8(input);
-  final utf8filename = Utf8.toUtf8(filename);
+  final utf8input = input.toNativeUtf8();
+  final utf8filename = filename.toNativeUtf8();
   final val = _jsEval(
     ctx,
     utf8input,
-    Utf8.strlen(utf8input),
+    utf8input.length,
     utf8filename,
     evalFlags,
   );
-  free(utf8input);
-  free(utf8filename);
+  malloc.free(utf8input);
+  malloc.free(utf8filename);
   runtimeOpaques[jsGetRuntime(ctx)]._port.sendPort.send(#eval);
   return val;
 }
@@ -413,9 +413,9 @@ Pointer jsNewString(
   Pointer ctx,
   String str,
 ) {
-  final utf8str = Utf8.toUtf8(str);
+  final utf8str = str.toNativeUtf8();
   final jsStr = _jsNewString(ctx, utf8str);
-  free(utf8str);
+  malloc.free(utf8str);
   return jsStr;
 }
 
@@ -599,7 +599,7 @@ String jsToCString(
 ) {
   final ptr = _jsToCString(ctx, val);
   if (ptr.address == 0) throw Exception('JSValue cannot convert to string');
-  final str = Utf8.fromUtf8(ptr);
+  final str = ptr.toDartString();
   jsFreeCString(ctx, ptr);
   return str;
 }
@@ -621,12 +621,12 @@ int jsNewClass(
   Pointer ctx,
   String name,
 ) {
-  final utf8name = Utf8.toUtf8(name);
+  final utf8name = name.toNativeUtf8();
   final val = _jsNewClass(
     ctx,
     utf8name,
   );
-  free(utf8name);
+  malloc.free(utf8name);
   return val;
 }
 
@@ -892,8 +892,8 @@ Pointer jsCall(
   Pointer thisObj,
   List<Pointer> argv,
 ) {
-  Pointer jsArgs = allocate<Uint8>(
-    count: argv.length > 0 ? sizeOfJSValue * argv.length : 1,
+  Pointer jsArgs = calloc<Uint8>(
+    argv.length > 0 ? sizeOfJSValue * argv.length : 1,
   );
   for (int i = 0; i < argv.length; ++i) {
     Pointer jsArg = argv[i];
@@ -906,7 +906,7 @@ Pointer jsCall(
     jsFreeValue(ctx, _thisObj);
   }
   jsFreeValue(ctx, func1);
-  free(jsArgs);
+  malloc.free(jsArgs);
   runtimeOpaques[jsGetRuntime(ctx)]._port.sendPort.send(#call);
   return jsRet;
 }

--- a/lib/src/wrapper.dart
+++ b/lib/src/wrapper.dart
@@ -66,7 +66,7 @@ Pointer _dartToJs(Pointer ctx, dynamic val, {Map<dynamic, dynamic> cache}) {
   }
   if (val is _JSObject) return jsDupValue(ctx, val._val);
   if (val is Future) {
-    final resolvingFunc = allocate<Uint8>(count: sizeOfJSValue * 2);
+    final resolvingFunc = malloc<Uint8>(sizeOfJSValue * 2);
     final resolvingFunc2 =
         Pointer.fromAddress(resolvingFunc.address + sizeOfJSValue);
     final ret = jsNewPromiseCapability(ctx, resolvingFunc);
@@ -74,7 +74,7 @@ Pointer _dartToJs(Pointer ctx, dynamic val, {Map<dynamic, dynamic> cache}) {
     _JSFunction rej = _jsToDart(ctx, resolvingFunc2);
     jsFreeValue(ctx, resolvingFunc, free: false);
     jsFreeValue(ctx, resolvingFunc2, free: false);
-    free(resolvingFunc);
+    malloc.free(resolvingFunc);
     _DartObject refRes = _DartObject(ctx, res);
     _DartObject refRej = _DartObject(ctx, rej);
     res.free();
@@ -95,11 +95,11 @@ Pointer _dartToJs(Pointer ctx, dynamic val, {Map<dynamic, dynamic> cache}) {
   if (val is double) return jsNewFloat64(ctx, val);
   if (val is String) return jsNewString(ctx, val);
   if (val is Uint8List) {
-    final ptr = allocate<Uint8>(count: val.length);
+    final ptr = malloc<Uint8>(val.length);
     final byteList = ptr.asTypedList(val.length);
     byteList.setAll(0, val);
     final ret = jsNewArrayBufferCopy(ctx, ptr, val.length);
-    free(ptr);
+    malloc.free(ptr);
     return ret;
   }
   if (cache.containsKey(val)) {
@@ -160,10 +160,10 @@ dynamic _jsToDart(Pointer ctx, Pointer val, {Map<int, dynamic> cache}) {
             rt, jsGetObjectOpaque(val, dartObjectClassId));
         if (dartObject != null) return dartObject._obj;
       }
-      Pointer<IntPtr> psize = allocate<IntPtr>();
+      Pointer<IntPtr> psize = malloc<IntPtr>();
       Pointer<Uint8> buf = jsGetArrayBuffer(ctx, psize, val);
       int size = psize.value;
-      free(psize);
+      malloc.free(psize);
       if (buf.address != 0) {
         return Uint8List.fromList(buf.asTypedList(size));
       }
@@ -215,11 +215,11 @@ dynamic _jsToDart(Pointer ctx, Pointer val, {Map<int, dynamic> cache}) {
         }
         return ret;
       } else {
-        Pointer<Pointer> ptab = allocate<Pointer>();
-        Pointer<Uint32> plen = allocate<Uint32>();
+        Pointer<Pointer> ptab = malloc<Pointer>();
+        Pointer<Uint32> plen = malloc<Uint32>();
         if (jsGetOwnPropertyNames(ctx, ptab, plen, val, -1) != 0) return null;
         int len = plen.value;
-        free(plen);
+        malloc.free(plen);
         Map<dynamic, dynamic> ret = Map();
         cache[valptr] = ret;
         for (int i = 0; i < len; ++i) {
@@ -233,7 +233,7 @@ dynamic _jsToDart(Pointer ctx, Pointer val, {Map<int, dynamic> cache}) {
           jsFreeAtom(ctx, jsAtom);
         }
         jsFree(ctx, ptab.value);
-        free(ptab);
+        malloc.free(ptab);
         return ret;
       }
       break;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  ffi: ^0.1.3
+  ffi: ^1.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Just replace the `allocate`, `free` and `Utf8` conversion parts to adapt `ffi 1.0.0` under the hint of IDE. 

At least `flutter test` all passed, and works on my simple project. Please refer the dart breaking changes talked in https://github.com/ekibun/flutter_qjs/issues/12 and check there is any bug.